### PR TITLE
chore: bump compatibility_date to 2026-06-12

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "katana-docs"
-compatibility_date = "2024-12-30"
+compatibility_date = "2026-06-12"
 placement = { mode = "smart" }
 preview_urls = false
 send_metrics = false


### PR DESCRIPTION
## Summary

- Bump the worker `compatibility_date` from `2024-12-30` to `2026-06-12` in `wrangler.toml`.

## Motivation

Follows Cloudflare's guidance to set `compatibility_date` to the current date, and keeps it consistent with the other Katana Cloudflare Workers projects (katana-ui, dex-frontend).

## Notes

This worker serves static assets only (no `main` script, no `nodejs_compat`), so `compatibility_date` has no runtime effect here — the change is purely for consistency. Wrangler is invoked via `cloudflare/wrangler-action` in CI; there is no local wrangler dependency to update.

## Objective

Keep the docs worker's compatibility date aligned with the rest of the fleet.