### PR TITLE
chore: bump compatibility_date to 2026-06-12 (#76)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "katana-docs"
-compatibility_date = "2024-12-30"
+compatibility_date = "2026-06-12"
 placement = { mode = "smart" }
 preview_urls = false
 send_metrics = false


### PR DESCRIPTION
Track Cloudflare's guidance to set the worker compatibility_date to the current date. The worker serves static assets only, so this has no runtime effect, but keeps the date consistent with the other Katana Cloudflare Workers projects.