### PR TITLE
fix: remove home page background mascot

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,6 @@ hide:
    </div>
 </div>
 
-<div class="mascot-container">
-</div>
 <div class="hero-left" style="max-width: 85%; margin: 0 auto; padding: 20px; text-align: left;">
    <p class="hero-subtext"><a href="https://katana.network/">Katana</a> is a chain designed specifically for DeFi. It rethinks DeFi to offer what users care about most: deeper liquidity and higher yields, all in a sustainable way. This happens through mechanisms to ensure that all liquidity on Katana is absorbed in only one lending protocol (Morpho), one spot DEX (Sushi), and one perp DEX (Vertex), which are the core applications on Katana with hundreds of applications building on top of them. This is achieved with a unique approach to maximizing yield that can be used as incentives on the core applications, including from <a href="https://polygon.technology/blog/introducing-vaultbridge-a-new-revenue-lego-for-evm-chains/">VaultBridge</a>, sequencer fees, and <a href="https://www.agora.finance/">Agora USD</a> revenue.</p>
    <p class="hero-subtext">Katana has deeply embedded, user-focused interoperability, using <a href="https://agglayer.dev/">Agglayer</a> for all users to onboard seamlessly. Katana uses ZK proofs to validate state transitions, allowing users to exit the chain without long wait periods.</p>


### PR DESCRIPTION
## Summary
Removes the decorative Katana mascot that renders as a fixed background image on the docs home page.

## Changes
- Delete the empty `<div class="mascot-container">` from `docs/index.md`, which was the element painting `katana_mascot_pose02.png` behind the landing content.

## Motivation
The background mascot is being retired from the docs landing page.

## Notes
- The `.mascot-container` CSS rules in `docs/_site_essentials/stylesheets/extra.css` are now unused but left in place (harmless dead styles). Can be stripped in a follow-up if desired.
- Verified locally via `mkdocs serve`: home page renders without the mascot and no build errors.
